### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/test-network-function/graphsolver-exports
 
-go 1.19
+go 1.20
 
 require github.com/test-network-function/l2discovery-exports v0.0.0-20220909220625-69bfab4b0fc1


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873