### PR TITLE
Update Go to v1.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/test-network-function/graphsolver-exports
 
-go 1.20
+go 1.21
 
 require github.com/test-network-function/l2discovery-exports v0.0.0-20220909220625-69bfab4b0fc1


### PR DESCRIPTION
https://go.dev/doc/go1.21

Related to: https://github.com/test-network-function/cnf-certification-test/pull/1344